### PR TITLE
fix(core): animation doesn't working

### DIFF
--- a/core/helper/keyframes.ts
+++ b/core/helper/keyframes.ts
@@ -4,7 +4,7 @@ import { generateUniqueName } from '@/utils'
 export function keyframes(kfString: TemplateStringsArray): string {
   const keyframeName = `kf-${generateUniqueName()}`
   injectStyle(
-    'keyframes',
+    keyframeName,
     [
       `
         @keyframes ${keyframeName} {

--- a/core/utils/injectStyle.ts
+++ b/core/utils/injectStyle.ts
@@ -26,7 +26,7 @@ function insert(className: string, cssString: string) {
   const ruleNode = insertedRuleMap[className]
   let rule = `.${className} { ${cssString} }`
 
-  if (className === 'global' || className === 'keyframes') {
+  if (className === 'global' || /^kf-.+/.test(className)) {
     rule = cssString
   }
 

--- a/docs/guide/basic/animations.md
+++ b/docs/guide/basic/animations.md
@@ -38,13 +38,13 @@ const StyledBaseDiv = styled.div`
 
 const StyledRotateDiv = styled(StyledBaseDiv)`
   background-color: skyblue;
-  animation: ${rotate} 2s linear infinite;
+  animation: ${rotate} 2s linear infinite !important;
 `
 
 const StyledTranslateDiv = styled(StyledBaseDiv)`
   margin-left: 10px;
   background-color: darkred;
-  animation: ${translate} 2s ease infinite alternate;
+  animation: ${translate} 2s ease infinite alternate !important;
 `
 </script>
 


### PR DESCRIPTION
1. vitepress blocks the animation and transition, so you need add `!important` to animation cover it.
    ```css
    /* node_modules/vitepress/dist/client/theme-default/styles/base.css */
    @media (prefers-reduced-motion: reduce) {
      *, ::before, ::after {
        animation-delay: -1ms !important;
        animation-duration: 1ms !important;
        animation-iteration-count: 1 !important;
        background-attachment: initial !important;
        scroll-behavior: auto !important;
        transition-duration: 0s !important;
        transition-delay: 0s !important;
      }
    }
    ```
2. keyframes names are always `keyframes` causing later keyframes to be overwritten. 
